### PR TITLE
Redirect push output to dev/null to avoid API keys ending up in logs

### DIFF
--- a/.ci/build-paper.sh
+++ b/.ci/build-paper.sh
@@ -20,7 +20,7 @@ then
     git status
     git -c user.name='travis' -c user.email='travis' commit -m "building the paper"
     git status
-    git push -f https://$GITHUB_USER:$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG HEAD:$TRAVIS_BRANCH-pdf
+    git push -f https://$GITHUB_USER:$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG HEAD:$TRAVIS_BRANCH-pdf >/dev/null 2>&1
 
     # Return to top level
     cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Travis CI's [best practices](https://docs.travis-ci.com/user/best-practices-security/#Steps-Travis-CI-takes-to-secure-your-data) recommend redirecting the output of git pushes to dev null.  Otherwise if the push fails, then the full command including the github api key can be printed to the CI log, which is bad.