### PR TITLE
Move build-paper step to script portion of travis workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,5 @@ before_script:
 script:
     # Run tests
     - py.test -v -s
-
-after_success:
     # Build and deploy the paper
     - source .ci/build-paper.sh


### PR DESCRIPTION
This PR simply moves the build-paper step of the travis workflow to the script section, so that the tectonic packages needed to build the paper are included in the travis cache.  This makes builds much faster (e.g. 1 minute vs 8 for one of my papers).